### PR TITLE
Update TheTemperance.java

### DIFF
--- a/src/main/java/shadowverse/cards/Vampire/Self/TheTemperance.java
+++ b/src/main/java/shadowverse/cards/Vampire/Self/TheTemperance.java
@@ -39,7 +39,7 @@ public class TheTemperance
 
     public TheTemperance() {
         super(ID, NAME, IMG_PATH, 4, DESCRIPTION, CardType.POWER, Vampire.Enums.COLOR_SCARLET, CardRarity.RARE, CardTarget.SELF);
-        this.baseMagicNumber = 3;
+        this.baseMagicNumber = 15;
         this.magicNumber = this.baseMagicNumber;
         this.exhaust = true;
     }
@@ -48,7 +48,7 @@ public class TheTemperance
     public void upgrade() {
         if (!this.upgraded) {
             upgradeName();
-            upgradeMagicNumber(1);
+            upgradeMagicNumber(5);
             this.rawDescription = cardStrings.UPGRADE_DESCRIPTION;
             initializeDescription();
         }


### PR DESCRIPTION
Proposal to buff Luzen. For comparison, Destruction in Black does 70 damage with Destruction in White active. Equal to 10 damage in Shadowverse. 70/10 = 7. So lowering max HP by 15 (20) per self damage is probably fair because 15 is roughly 2 damage in Shadowverse.